### PR TITLE
Fix typo 'exists' in help command, changed to 'exits'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ websvr~$ help
   Commands
   
     help [command]    Provides help for a given command.
-    exit [options]    Exists instance of Vantage.
+    exit [options]    Exits instance of Vantage.
     use <module>      Installs a vantage extension in realtime.
     vantage [server]  Connects to another application running vantage.
     foo               Outputs "bar".

--- a/lib/vantage-commons.js
+++ b/lib/vantage-commons.js
@@ -46,7 +46,7 @@ module.exports = function(vantage) {
   vantage
     .command("exit")
     .option("-f, --force", "Forces process kill without confirmation.")
-    .description("Exists instance of Vantage.")
+    .description("Exits instance of Vantage.")
     .action(function(args) {
       args.options = args.options || {};
       args.options.sessionId = this.id;


### PR DESCRIPTION
Fixed a typo in the help command (and readme), replacing 'Exists instance of Vantage' with 'Exits instance of Vantage'.