### PR TITLE
Better support for HapiJS connections

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -107,8 +107,18 @@ vantageServer.init = function(app, options, cb) {
 
   if (appIs === "hapi") {
     this.server = app;
-    this.server.connection({ port: options.port });
-    this.io = require("socket.io")(this.server.listener);
+
+    // Create a connection if none exist.
+    if (this.server.connections.length === 0) {
+      this.server.connection({ port: options.port, labels: "vantage" });
+      this.io = require("socket.io")(this.server.listener);
+    } else if (this.server.connections.length > 1) {
+      // Select a specific connection if more than one exist.
+      this.io = require("socket.io")(this.server.select(options.connectionLabel || "vantage").listener);
+      delete options.connectionLabel;
+    } else {
+      this.io = require("socket.io")(this.server.listener);
+    }
   } else {
     var type = (options.ssl) ? "https" : "http";
     if (type === "http") {


### PR DESCRIPTION
Hapi has a few different states for connections, by default there isn't a "connection" until `server.connection` is called.

This PR handles

No `.connection` call (creates a labelled connection for vantage)
Multiple connections with an option to select a specific server via the `options` and `connectionLabel`
Singular `.connection` call.

Hope it helps!