### PR TITLE
feat(auth): Allow passthrough of options from the client connect to the server authentication

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -286,7 +286,8 @@ vantageClient.connect = function(server, port, options, cb) {
         handshake: (ssn.client.io.opts || {}),
         user: options.user,
         pass: options.pass,
-        sessionId: ssn.id
+        sessionId: ssn.id,
+        client: options
       };
 
       self.parent._send("vantage-auth-upstream", "upstream", authData);


### PR DESCRIPTION
This allows the following pattern to be used:

```js
//client side
vantage.command('remote', 'Connect to remote server cli')
    .option('-p --port <port>', 'Port number', [3001])
    .option('-h --host <host>', 'Host address number', ['localhost'])
    .action(function (args, callback) {

      const port = args.options.port || 3001;
      const host = args.options.host || 'localhost';

      return getSignedJwt(this, project, 'admin')
        .then((jwt) => cli.connect(host, port, {jwt})) //note the jwt token is being passed as the third options argument
        .catch((err) => {
          this.log('Error connecting to remote cli:', err);
          callback();
        });
    });
```
```ts
//server side
this.vantage.auth((vantage: any, options: any) => {
      return (args: any, cb: Function) => {
        try {
          if (args.client.jwt && this.authService.verify(args.client.jwt)){
            return cb('Ok', true);
          }

          return cb("Credentials are incorrect", false);
        } catch (e){
          this.logger.error('Authentication error', e);
          cb(null, false);
        }
      }
    });
```