### PR TITLE
fix ReferenceError: chalk is not defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var VantageServer = require("./server");
 var VantageClient = require("./client");
 var commons = require("./vantage-commons");
 var repl = require("vorpal-repl");
+var chalk = require('chalk');
 
 function Vantage() {
 


### PR DESCRIPTION
When I try to connect to a vantage server with client. I get an error:

> [ERROR] (node:15363) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ReferenceError: chalk is not defined

printed to console of server process.

this fixes the bug